### PR TITLE
Attempt 5 Retries for grafana plugins download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN sed -i 's#<title>Grafana</title>#<title>Grafana XXL</title>#g' /usr/share/gr
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*  
 
-#VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
+VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,16 @@ RUN \
   apt-get -y --force-yes --no-install-recommends install libfontconfig curl ca-certificates git jq && \
   curl https://grafanarel.s3.amazonaws.com/builds/grafana_${GRAFANA_VERSION}_amd64.deb > /tmp/grafana.deb && \
   dpkg -i /tmp/grafana.deb && \
-  rm -f /tmp/grafana.deb && \
-  curl -L https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64 > /usr/sbin/gosu && \
-  chmod +x /usr/sbin/gosu && \
-  for plugin in $(curl -s https://grafana.net/api/plugins?orderBy=name | jq '.items[] | select(.internal=='false') | .slug' | tr -d '"'); do grafana-cli --pluginsDir "${GF_PLUGIN_DIR}" plugins install $plugin; done && \
+  rm -f /tmp/grafana.deb
+
+RUN  curl -L https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64 > /usr/sbin/gosu && \
+  chmod +x /usr/sbin/gosu
+
+RUN \
+  for plugin in $(curl -s https://grafana.net/api/plugins?orderBy=name | jq '.items[] | select(.internal=='false') | .slug' | tr -d '"'); \
+    do rc=1;count=0; while [ $rc -ne 0 ] && [ $count -lt 5 ]; do grafana-cli --pluginsDir "${GF_PLUGIN_DIR}" plugins install $plugin;rc=$?;count=$(( count+1 )); done; done
   ### branding && \
-  sed -i 's#<title>Grafana</title>#<title>Grafana XXL</title>#g' /usr/share/grafana/public/views/index.html && \
+RUN sed -i 's#<title>Grafana</title>#<title>Grafana XXL</title>#g' /usr/share/grafana/public/views/index.html && \
   sed -i 's#<title>Grafana</title>#<title>Grafana XXL</title>#g' /usr/share/grafana/public/views/500.html && \
   sed -i 's#icon-gf-grafana_wordmark"></i>#icon-gf-grafana_wordmark"> XXL</i>#g' /usr/share/grafana/public/app/app_bundle.js && \
   sed -i 's#icon-gf-grafana_wordmark"></i>#icon-gf-grafana_wordmark"> XXL</i>#g' /usr/share/grafana/public/app/boot.js && \
@@ -41,7 +45,7 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*  
 
-VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
+#VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
 
 EXPOSE 3000
 


### PR DESCRIPTION
Attempt up to 6 (hardcoded in dockerfile) Retries for grafana plugins downloads,
because grafana plugins server has not been stable for a while, and as a result, building grafana-xxl results in an incomplete image, and may lack some essential plugins since there was 1 download failure.

6 download attempts are much safer to properly download a plugin.