### PR TITLE
Override incorrect ARM version detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM ubuntu:xenial
 MAINTAINER Jan Garaj info@monitoringartist.com
 
 ARG GRAFANA_ARCHITECTURE=amd64
@@ -21,7 +21,7 @@ COPY ./run.sh /run.sh
 
 RUN \
   apt-get update && \
-  apt-get -y --force-yes --no-install-recommends install libfontconfig curl ca-certificates git jq && \
+  apt-get -y --force-yes --no-install-recommends install libfontconfig curl ca-certificates git jq apt-utils && \
   curl -L ${GRAFANA_DEB_URL} > /tmp/grafana.deb && \
   dpkg -i /tmp/grafana.deb && \
   rm -f /tmp/grafana.deb && \


### PR DESCRIPTION
I faced with the problem of arm version detection inside docker container (armhf vs armel, https://github.com/moby/moby/issues/34875) on my Odroid XU4 (with deb from https://github.com/fg2it/grafana-on-raspberry). With debian:jessie i can't install armhf deb package on armhf-compatible platform, i got something like this:
```
dpkg: error processing archive grafana_5.0.4_armhf.deb (--install):
 package architecture (armhf) does not match system (armel)
```

Simple compare ubuntu vs debian about dpkg architecture :
```
root@manager:~# dpkg --print-architecture
armhf
root@manager:~# docker run --rm -it ubuntu:xenial dpkg --print-architecture
armhf
root@manager:~# docker run --rm -it debian:jessie dpkg --print-architecture
armel
```
I believe that using ubuntu:xenial instead of debian:jessie increase a chance to succefull installation grafana-xxl on different arm platforms.
