### PR TITLE
Allow to specify config and homepath arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ ENV \
   GF_PLUGIN_DIR=/grafana-plugins \
   GF_PATHS_LOGS=/var/log/grafana \
   GF_PATHS_DATA=/var/lib/grafana \
+  GF_PATHS_CONFIG=/etc/grafana/grafana.ini \
+  GF_PATHS_HOME=/usr/share/grafana \
   UPGRADEALL=true
 
 COPY ./run.sh /run.sh

--- a/run.sh
+++ b/run.sh
@@ -28,8 +28,8 @@ if [ "$UPGRADEALL" = true ] ; then
 fi
 
 exec gosu grafana /usr/sbin/grafana-server   \
-  --homepath=/usr/share/grafana              \
-  --config=/etc/grafana/grafana.ini          \
+  --homepath="${GF_PATHS_HOME}"              \
+  --config="${GF_PATHS_CONFIG}"              \
   cfg:default.paths.data=${GF_PATHS_DATA}    \
   cfg:default.paths.logs=${GF_PATHS_LOGS}    \
   cfg:default.paths.plugins=${GF_PLUGIN_DIR} \


### PR DESCRIPTION
The change allows to use `GF_PATHS_HOME` to set the `--homepath` and `GF_PATHS_CONFIG` to set the `--config` arguments passed to `grafana-server`.

This matches the behaviour of the official docker image:

See: http://docs.grafana.org/installation/docker/#default-paths

And: https://github.com/grafana/grafana/blob/master/packaging/docker/run.sh#L81 for the code of the `run.sh` script.