### PR TITLE
updated to grafana 5.4.3 and updated branding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 MAINTAINER Jan Garaj info@monitoringartist.com
 
 ARG GRAFANA_ARCHITECTURE=amd64
-ARG GRAFANA_VERSION=5.2.0
+ARG GRAFANA_VERSION=5.3.1
 ARG GRAFANA_DEB_URL=https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_${GRAFANA_VERSION}_${GRAFANA_ARCHITECTURE}.deb
 ARG GOSU_BIN_URL=https://github.com/tianon/gosu/releases/download/1.10/gosu-${GRAFANA_ARCHITECTURE}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 MAINTAINER Jan Garaj info@monitoringartist.com
 
 ARG GRAFANA_ARCHITECTURE=amd64
-ARG GRAFANA_VERSION=5.3.1
+ARG GRAFANA_VERSION=5.4.3
 ARG GRAFANA_DEB_URL=https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_${GRAFANA_VERSION}_${GRAFANA_ARCHITECTURE}.deb
 ARG GOSU_BIN_URL=https://github.com/tianon/gosu/releases/download/1.10/gosu-${GRAFANA_ARCHITECTURE}
 
@@ -15,13 +15,17 @@ ENV \
   GF_PLUGIN_DIR=/grafana-plugins \
   GF_PATHS_LOGS=/var/log/grafana \
   GF_PATHS_DATA=/var/lib/grafana \
+  GF_PATHS_CONFIG=/etc/grafana/grafana.ini \
+  GF_PATHS_HOME=/usr/share/grafana \
   UPGRADEALL=true
 
 COPY ./run.sh /run.sh
 
 RUN \
   apt-get update && \
-  apt-get -y --force-yes --no-install-recommends install libfontconfig curl ca-certificates git jq && \
+  apt-get -y --force-yes --no-install-recommends install libfontconfig curl ca-certificates git jq
+
+RUN \
   curl -L ${GRAFANA_DEB_URL} > /tmp/grafana.deb && \
   dpkg -i /tmp/grafana.deb && \
   rm -f /tmp/grafana.deb && \
@@ -29,10 +33,8 @@ RUN \
   chmod +x /usr/sbin/gosu && \
   for plugin in $(curl -s https://grafana.net/api/plugins?orderBy=name | jq '.items[] | select(.internal=='false') | .slug' | tr -d '"'); do grafana-cli --pluginsDir "${GF_PLUGIN_DIR}" plugins install $plugin; done && \
   ### branding && \
-  sed -i 's#<title>Grafana</title>#<title>Grafana XXL</title>#g' /usr/share/grafana/public/views/index.template.html && \
-  sed -i 's#<title>Grafana</title>#<title>Grafana XXL</title>#g' /usr/share/grafana/public/views/index.html && \
-  sed -i 's#<title>Grafana - Error</title>#<title>Grafana XXL - Error</title>#g' /usr/share/grafana/public/views/error.html && \
-  sed -i 's#icon-gf-grafana_wordmark"></i>#icon-gf-grafana_wordmark"> XXL</i>#g' /usr/share/grafana/public/app/partials/login.html && \
+  sed -i 's#<title>Grafana</title>#<title>Grafana XXL</title>#g' /usr/share/grafana/public/views/index-template.html && \
+  sed -i 's#<title>Grafana - Error</title>#<title>Grafana XXL - Error</title>#g' /usr/share/grafana/public/views/error-template.html && \
   chmod +x /run.sh && \
   mkdir -p /usr/share/grafana/.aws/ && \
   touch /usr/share/grafana/.aws/credentials && \
@@ -40,6 +42,8 @@ RUN \
   apt-get autoremove -y --force-yes && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+COPY ./assets/grafana_typelogo.svg /usr/share/grafana/public/img/grafana_typelogo.svg
 
 VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
 

--- a/assets/grafana_typelogo.svg
+++ b/assets/grafana_typelogo.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="228"
+   height="36.599998"
+   viewBox="0 0 228 36.6"
+   xml:space="preserve"
+   sodipodi:docname="grafana_typelogo.svg"
+   inkscape:version="0.92.3 (9d3ec66c42, 2018-09-11)"><metadata
+   id="metadata901"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs899" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1454"
+   inkscape:window-height="851"
+   id="namedview897"
+   showgrid="false"
+   inkscape:zoom="3.7400265"
+   inkscape:cx="130.61298"
+   inkscape:cy="18.216082"
+   inkscape:window-x="0"
+   inkscape:window-y="23"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="g894" />
+<style
+   type="text/css"
+   id="style878">
+	.st0{fill:#E6E7E8;}
+</style>
+<g
+   id="g894"
+   transform="translate(0,1.9836426e-5)">
+	
+	
+	
+	
+	
+	
+	
+<g
+   id="g2082"
+   transform="matrix(1.3605982,0,0,1.3605982,-0.14423929,-15.262274)"><path
+     style="fill:#e6e7e8;stroke-width:0.64061922"
+     inkscape:connector-curvature="0"
+     id="path880"
+     d="M 21.988867,24.997901 C 21.732619,30.95566 17.056099,35.63218 11.162403,35.63218 4.9483963,35.63218 0.4,30.63535 0.4,24.549468 c 0,-6.085882 4.9968298,-11.082712 11.082712,-11.082712 2.754663,0 5.445263,1.153114 7.687431,3.33122 l -1.793734,2.178105 c -1.729672,-1.473424 -3.843715,-2.562477 -5.893697,-2.562477 -4.4843342,0 -8.1358637,3.65153 -8.1358637,8.135864 0,4.548396 3.4593437,8.135864 7.8155547,8.135864 3.971839,0 7.046811,-2.882787 7.68743,-6.598378 H 9.8811642 V 23.460415 H 21.988867 Z"
+     class="st0" /><path
+     style="fill:#e6e7e8;stroke-width:0.64061922"
+     inkscape:connector-curvature="0"
+     id="path882"
+     d="m 32.302836,23.524477 h -1.66561 c -1.793733,0 -3.33122,1.473424 -3.33122,3.33122 v 8.584297 H 24.359158 V 20.705753 h 2.434353 v 1.217176 c 0.768743,-0.768743 2.049982,-1.217176 3.459344,-1.217176 h 3.203096 z"
+     class="st0" /><path
+     style="fill:#e6e7e8;stroke-width:0.64061922"
+     inkscape:connector-curvature="0"
+     id="path884"
+     d="m 48.382378,35.439994 h -2.498415 v -1.857795 c -1.921857,1.921857 -4.996829,2.818724 -8.071802,1.473424 -2.306229,-1.024991 -3.971839,-3.074972 -4.484334,-5.573387 -0.896867,-4.740582 2.818724,-8.968669 7.495245,-8.968669 1.985919,0 3.715591,0.768743 5.060891,2.114043 v -1.857795 h 2.562477 v 14.670179 z m -3.01091,-6.278068 c 0.704681,-3.01091 -1.601548,-5.701511 -4.548396,-5.701511 -2.562477,0 -4.612459,2.114044 -4.612459,4.612459 0,2.882786 2.498415,5.060891 5.445264,4.612458 1.793733,-0.384372 3.267157,-1.729672 3.715591,-3.523406 z"
+     class="st0" /><path
+     style="fill:#e6e7e8;stroke-width:0.64061922"
+     inkscape:connector-curvature="0"
+     id="path886"
+     d="m 54.276075,19.872948 v 0.832805 h 4.67652 v 2.562477 h -4.67652 V 35.439994 H 51.393288 V 20.001072 c 0,-3.267158 2.30623,-5.189016 5.253078,-5.189016 h 3.523405 l -1.153114,2.754663 h -2.370291 c -1.3453,0 -2.370291,1.02499 -2.370291,2.306229 z"
+     class="st0" /><path
+     style="fill:#e6e7e8;stroke-width:0.64061922"
+     inkscape:connector-curvature="0"
+     id="path888"
+     d="m 74.583704,35.439994 h -2.498415 v -1.857795 c -1.921858,1.921857 -4.99683,2.818724 -8.071802,1.473424 -2.306229,-1.024991 -3.971839,-3.074972 -4.484335,-5.573387 -0.896867,-4.740582 2.818725,-8.968669 7.495245,-8.968669 1.985919,0 3.715591,0.768743 5.060892,2.114043 v -1.857795 h 2.562476 v 14.670179 z m -3.010911,-6.278068 c 0.704681,-3.01091 -1.601548,-5.701511 -4.548396,-5.701511 -2.562477,0 -4.612458,2.114044 -4.612458,4.612459 0,2.882786 2.498415,5.060891 5.445263,4.612458 1.857796,-0.384372 3.33122,-1.729672 3.715591,-3.523406 z"
+     class="st0" /><path
+     style="fill:#e6e7e8;stroke-width:0.64061922"
+     inkscape:connector-curvature="0"
+     id="path890"
+     d="m 90.342936,26.727573 v 8.712421 h -2.946848 v -8.712421 c 0,-1.857795 -1.473425,-3.33122 -3.33122,-3.33122 -1.857796,0 -3.33122,1.473425 -3.33122,3.33122 v 8.712421 H 77.7868 V 20.705753 h 2.434352 v 1.281238 c 1.089053,-0.960929 2.498415,-1.473424 3.97184,-1.473424 3.459343,-0.06406 6.149944,2.754663 6.149944,6.214006 z"
+     class="st0" /><path
+     style="fill:#e6e7e8;stroke-width:0.64061922"
+     inkscape:connector-curvature="0"
+     id="path892"
+     d="m 107.70372,35.439994 h -2.49842 v -1.857795 c -1.92186,1.921857 -4.99683,2.818724 -8.071801,1.473424 -2.306229,-1.024991 -3.971839,-3.074972 -4.484334,-5.573387 -0.896867,-4.740582 2.818724,-8.968669 7.495245,-8.968669 1.98592,0 3.71559,0.768743 5.06089,2.114043 v -1.857795 h 2.56248 v 14.670179 z m -3.07498,-6.278068 c 0.70469,-3.01091 -1.60154,-5.701511 -4.54839,-5.701511 -2.562479,0 -4.612461,2.114044 -4.612461,4.612459 0,2.882786 2.498415,5.060891 5.445261,4.612458 1.8578,-0.384372 3.33122,-1.729672 3.71559,-3.523406 z"
+     class="st0" /><text
+     id="text905"
+     y="35.496338"
+     x="109.54709"
+     style="font-style:normal;font-weight:normal;font-size:29.7169075px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:none;fill-opacity:1;stroke:#e6e7e8;stroke-width:0.74292266;stroke-opacity:1"
+     xml:space="preserve"><tspan
+       style="fill:none;stroke:#e6e7e8;stroke-width:0.74292266;stroke-opacity:1"
+       y="35.496338"
+       x="109.54709"
+       id="tspan903"
+       sodipodi:role="line">XXL</tspan></text>
+</g>
+</g>
+</svg>


### PR DESCRIPTION
The commands that used `sed` for branding things grafana-xxl no longer work, but I updated them to the right assets anyway. The page titles are handled by the angular controllers, it seems. Grafana's `public/app/core/config.ts` *could* be updated with:

`  sed -i 's#      windowTitlePrefix: 'Grafana - ',#      windowTitlePrefix: 'Grafana XXL - ',#g' /usr/share/grafana/public/views/index-template.html && \`

but it doesn't take effect without rebuilding grafana. This could be a reason to build from source instead of from the .deb package...

I was having a bunch of trouble getting docker to build this thing due to the Debian mirrors constantly being out of sync, packages missing, etc. so I moved some docker commands around a little to avoid having to install packages every time. It creates more docker layers, but it's worth the trouble IMO.

I also created a grafana xxl graphic (modified the existing one)