### PR TITLE
upped to grafana 7.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 MAINTAINER Jan Garaj info@monitoringartist.com
 
 ARG GRAFANA_ARCHITECTURE=amd64
-ARG GRAFANA_VERSION=6.7.1
+ARG GRAFANA_VERSION=7.0.6
 ARG GRAFANA_DEB_URL=https://dl.grafana.com/oss/release/grafana_${GRAFANA_VERSION}_${GRAFANA_ARCHITECTURE}.deb
 ARG GOSU_BIN_URL=https://github.com/tianon/gosu/releases/download/1.10/gosu-${GRAFANA_ARCHITECTURE}
 
@@ -31,9 +31,6 @@ RUN \
   curl -L ${GOSU_BIN_URL} > /usr/sbin/gosu && \
   chmod +x /usr/sbin/gosu && \
   for plugin in $(curl -s https://grafana.net/api/plugins?orderBy=name | jq '.items[] | select(.internal == false) | .slug' | tr -d '"'); do grafana-cli --pluginsDir "${GF_PLUGIN_DIR}" plugins install $plugin; done && \
-  ### branding && \
-  sed -i 's#<title>Grafana</title>#<title>Grafana XXL</title>#g' /usr/share/grafana/public/views/index-template.html && \
-  sed -i 's#<title>Grafana - Error</title>#<title>Grafana XXL - Error</title>#g' /usr/share/grafana/public/views/error-template.html && \
   chmod +x /run.sh && \
   mkdir -p /usr/share/grafana/.aws/ && \
   touch /usr/share/grafana/.aws/credentials && \
@@ -41,6 +38,11 @@ RUN \
   apt-get autoremove -y --allow-downgrades --allow-remove-essential --allow-change-held-packages && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+### branding
+RUN \
+  sed -i 's/<title>\[\[\.AppTitle\]\]<\/title>/<title>Grafana XXL<\/title>/g' /usr/share/grafana/public/views/index-template.html && \
+  sed -i 's/<title>Grafana - Error<\/title>/<title>Grafana XXL - Error<\/title>/g' /usr/share/grafana/public/views/error-template.html
 
 VOLUME ["/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
 


### PR DESCRIPTION
note that in order for snapshots to work and maybe a couple other things I don't remember, there has to be an 'image rendering' service accessible to grafana. Grafana devs have one and it can be run like so (local to grafana):

```
docker run --rm \
    --name renderer \
    -p 8081:8081 \
    grafana/grafana-image-renderer:2.0.0
```

and your grafana config file should reference it:
```
[rendering]
; server_url = http://renderer:8081/render
; callback_url = https://[yourgrafana.com]/
; concurrent_render_request_limit = 30
```

or you can add environment variables to reference it when running grafana:
```
  -e "GF_RENDERING_SERVER_URL=http://renderer:8081/render" \
  -e "GF_RENDERING_CALLBACK_URL=https://[yourgrafana.com]" \
```

