### PR TITLE
Grafana 8.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 MAINTAINER Jan Garaj info@monitoringartist.com
 
 ARG GRAFANA_ARCHITECTURE=amd64
-ARG GRAFANA_VERSION=8.0.2
+ARG GRAFANA_VERSION=8.3.3
 ARG GRAFANA_DEB_URL=https://dl.grafana.com/oss/release/grafana_${GRAFANA_VERSION}_${GRAFANA_ARCHITECTURE}.deb
 ARG GOSU_BIN_URL=https://github.com/tianon/gosu/releases/download/1.10/gosu-${GRAFANA_ARCHITECTURE}
 


### PR DESCRIPTION
It includes a fix to CVE-2021-43798.
See https://grafana.com/blog/2021/12/08/an-update-on-0day-cve-2021-43798-grafana-directory-traversal/

I tried an upgrade of Grafana XXL from Grafana 8.0.2 to 8.3.3 and did not see any issue, however it was a fresh instance with no data.